### PR TITLE
Fix equality check in getAnalyticsEndpoint()

### DIFF
--- a/src/globals.ts
+++ b/src/globals.ts
@@ -55,7 +55,7 @@ export const TEXT_DECODER = new TextDecoder()
 export const MAINNET_ANALYTICS_ENDPOINT = "https://api-dev.algofi.org"
 export const TESTNET_ANALYTICS_ENDPOINT = "https://api-dev.algofi.org"
 export function getAnalyticsEndpoint(network: Network): string {
-  if (network = Network.MAINNET) {
+  if (network == Network.MAINNET) {
     return MAINNET_ANALYTICS_ENDPOINT
   } else {
     return TESTNET_ANALYTICS_ENDPOINT


### PR DESCRIPTION
#### Issue
function [getAnalyticsEndpoint](https://github.com/Algofiorg/algofi-javascript-sdk/blob/main/src/globals.ts#L57) uses "=" instead of "==" when comparing input param *network* with constant *Network.MAINNET*. This turned an equality check into an assignment, leading to unexpected behavior.

#### Impact
The function is meant to return the analytics endpoint for mainnet or testnet, depending on the input param. This endpoint is then used to fetch Algofi data, such as asset / token prices. Without a fix, all inputs return the same endpoint.

That said, there is no current impact since both mainnet and testnet endpoints are the same (https://api-dev.algofi.org). However, this can change in the future and the function should properly account for this.