### PR TITLE
Fix AMMClient.loadState()

### DIFF
--- a/src/amm/v1/ammClient.ts
+++ b/src/amm/v1/ammClient.ts
@@ -35,7 +35,7 @@ export default class AMMClient {
   }
 
   async loadState() {
-    request
+    await request
       .get(getAnalyticsEndpoint(this.network) + "/pools?network=" + getNetworkName(this.network))
       .then(resp => {
         if (resp.status == 200) {


### PR DESCRIPTION
#### Issue
AMMClient.loadState() makes an async request to fetch pool data but does not wait for completion before returning.

#### Impact
This causes a race condition. Users expect fulfillment of the promise returned by loadState() to signal the client's state has been loaded / updated. However, because the internal request is not waited for, the function returns immediately with the client in an undetermined state. If the client is used too soon, unexpected / wrong data is possible. This client is used by other library classes (such as AlgofiClient), so this can have many downstream effects